### PR TITLE
Add support for AAD auth

### DIFF
--- a/Web.NetCore/GraphExplorer/GraphExplorer.csproj
+++ b/Web.NetCore/GraphExplorer/GraphExplorer.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspnetCore.Authentication.Cookies" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspnetCore.Authentication.OpenIdConnect" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.1.2" />

--- a/Web.NetCore/GraphExplorer/appsettings.json
+++ b/Web.NetCore/GraphExplorer/appsettings.json
@@ -1,4 +1,16 @@
 {
+  "Authentication":
+  {
+    "UseAuthentication": false,
+    "AzureAd":
+    {
+      "AADInstance": "https://login.microsoftonline.com/",
+      "CallbackPath": "/signin-oidc",
+      "ClientId": "YOURCLIENTID",
+      "Domain": "microsoft.onmicrosoft.com",
+      "TenantId": "YOURTENANTID"
+    }
+  },
   "DocumentDBConfig":
   {
     "endpoint": "DOCUMENTDBURL",

--- a/Web.NetCore/GraphExplorer/tsconfig.json
+++ b/Web.NetCore/GraphExplorer/tsconfig.json
@@ -6,8 +6,7 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "skipDefaultLibCheck": true,
-    "lib": [ "es2015", "dom" ],
-    "types": [ "node" ]
+    "lib": [ "es2015", "dom" ]
   },
   "exclude": [ "bin", "node_modules" ],
   "atom": { "rewriteTsconfig": false }


### PR DESCRIPTION
Aad auth support for the .NET Core version of GraphExplorer.

Update appsettings.json with your ClientId and TenantId, then set "UseAuthentication" to true. 