### PR TITLE
Fixing issue #6

### DIFF
--- a/Web/GraphExplorer/GraphExplorer.csproj
+++ b/Web/GraphExplorer/GraphExplorer.csproj
@@ -293,6 +293,7 @@
     <Content Include="Views\Shared\_Layout.cshtml" />
     <Content Include="Views\Home\Index.cshtml" />
     <Content Include="tsconfig.json" />
+    <Content Include="wwwroot/**/*.*" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="App_Data\graphsettings.json" />


### PR DESCRIPTION
This change fixes https://github.com/Azure-Samples/azure-cosmos-db-dotnet-graphexplorer/issues/6 

Since the `wwwroot` content is not part of the project, when publishing to Azure, it won't get uploaded.